### PR TITLE
Improve Manchester profile

### DIFF
--- a/Manchester.json
+++ b/Manchester.json
@@ -145,7 +145,7 @@
             "calmWindSpeed": 2,
             "template": {
               "text": "{wind}",
-              "voice": "WIND CALM"
+              "voice": "SURFACE WIND CALM"
             }
           }
         },

--- a/Manchester.json
+++ b/Manchester.json
@@ -1,130 +1,344 @@
 {
-  "Name": "Manchester",
-  "Composites": [
+  "name": "Manchester",
+  "id": "c6fa55e1-6736-4c6b-acec-65414e3b8eab",
+  "composites": [
     {
-      "Name": "Manchester",
-      "Identifier": "EGCC",
-      "Contractions": [
+      "id": "1e66596a-ac0a-401a-9c97-ea18169bab1c",
+      "name": "Manchester",
+      "identifier": "EGCC",
+      "atisType": "Combined",
+      "codeRange": {
+        "low": "A",
+        "high": "Z"
+      },
+      "frequency": 121975000,
+      "atisVoice": {
+        "useTextToSpeech": true,
+        "voice": "UK Female"
+      },
+      "idsEndpoint": "",
+      "useNotamPrefix": false,
+      "useDecimalTerminology": true,
+      "airportConditionsBeforeFreeText": false,
+      "notamsBeforeFreeText": true,
+      "presets": [
         {
-          "String": "H24",
-          "Spoken": "TWENTY FOUR HOURS"
+          "id": "0188d9c8-46ce-47fd-9e0a-c78efd927328",
+          "name": "23R",
+          "airportConditions": "",
+          "notams": "",
+          "template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. RUNWAY IN USE RWY 23R. SINGLE RUNWAY OPERATIONS. [TL]. [WX]. [ARPT_COND] [NOTAMS]",
+          "externalGenerator": {
+            "enabled": false
+          }
         },
         {
-          "String": "23R",
-          "Spoken": "TWO THREE RIGHT"
+          "id": "298b3005-0cd6-4a7c-9adc-916e9c8df15e",
+          "name": "23 Duals",
+          "notams": "",
+          "template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. ARRIVAL RUNWAY 23R, DEPARTURE RUNWAY 23L. [TL]. [WX]. [ARPT_COND] [NOTAMS]",
+          "externalGenerator": {
+            "enabled": false
+          }
         },
         {
-          "String": "23L",
-          "Spoken": "TWO THREE LEFT"
+          "id": "e3744774-63f4-4ef1-b46e-3b29d2c30662",
+          "name": "05L",
+          "template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. RUNWAY IN USE RWY 05L. SINGLE RUNWAY OPERATIONS. [TL]. [WX]. [ARPT_COND] [NOTAMS]",
+          "externalGenerator": {
+            "enabled": false
+          }
         },
         {
-          "String": "05L",
-          "Spoken": "ZERO FIVE LEFT"
+          "id": "7a231f22-7e63-435e-9db8-ce09bdc08ddf",
+          "name": "05 Duals",
+          "template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. ARRIVAL RUNWAY 05R, DEPARTURE RUNWAY 05L. [TL]. [WX]. [ARPT_COND] [NOTAMS]",
+          "externalGenerator": {
+            "enabled": false
+          }
         },
         {
-          "String": "05R",
-          "Spoken": "ZERO FIVE RIGHT"
+          "id": "a336c75a-f972-43d7-89c9-11def18e537a",
+          "name": "23L",
+          "template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. RUNWAY IN USE RWY 23L. SINGLE RUNWAY OPERATIONS. [TL]. [WX]. [ARPT_COND] [NOTAMS]",
+          "externalGenerator": {
+            "enabled": false
+          }
+        },
+        {
+          "id": "d775f48c-eb22-4c8e-b720-4c95f21e9a69",
+          "name": "05R",
+          "template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. RUNWAY IN USE RWY 05R. SINGLE RUNWAY OPERATIONS. [TL]. [WX]. [ARPT_COND] [NOTAMS]",
+          "externalGenerator": {
+            "enabled": false
+          }
         }
       ],
-      "AtisFrequency": 21975,
-      "ObservationTime": {
-        "Enabled": false,
-        "Time": 0
-      },
-      "MagneticVariation": {
-        "Enabled": false,
-        "MagneticDegrees": 0
-      },
-      "AtisVoice": {
-        "UseTextToSpeech": true,
-        "Voice": "UK Female"
-      },
-      "IDSEndpoint": null,
-      "Presets": [
+      "contractions": [
         {
-          "Name": "23R",
-          "AirportConditions": null,
-          "Notams": null,
-          "ArbitraryText": null,
-          "Template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. RUNWAY IN USE 23R. SINGLE RUNWAY OPERATIONS. [TL]. [WX]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND REPORT AIRCRAFT TYPE AND CLEARED LEVEL ON FIRST CONTACT WITH MANCHESTER APPROACH RADAR."
+          "string": "H24",
+          "spoken": "TWENTY FOUR HOURS"
         },
         {
-          "Name": "23 Duals",
-          "AirportConditions": null,
-          "Notams": null,
-          "ArbitraryText": null,
-          "Template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. ARRIVAL RUNWAY 23R, DEPARTURE RUNWAY 23L. [TL]. [WX]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND REPORT AIRCRAFT TYPE AND CLEARED LEVEL ON FIRST CONTACT WITH MANCHESTER APPROACH RADAR."
+          "string": "23R",
+          "spoken": "TWO THREE RIGHT"
         },
         {
-          "Name": "05L",
-          "AirportConditions": null,
-          "Notams": null,
-          "ArbitraryText": null,
-          "Template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. RUNWAY IN USE 05L. SINGLE RUNWAY OPERATIONS. [TL]. [WX]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND REPORT AIRCRAFT TYPE AND CLEARED LEVEL ON FIRST CONTACT WITH MANCHESTER APPROACH RADAR."
+          "string": "23L",
+          "spoken": "TWO THREE LEFT"
         },
         {
-          "Name": "05 Duals",
-          "AirportConditions": null,
-          "Notams": null,
-          "ArbitraryText": null,
-          "Template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. ARRIVAL RUNWAY 05R, DEPARTURE RUNWAY 05L. [TL]. [WX]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND REPORT AIRCRAFT TYPE AND CLEARED LEVEL ON FIRST CONTACT WITH MANCHESTER APPROACH RADAR."
+          "string": "05L",
+          "spoken": "ZERO FIVE LEFT"
         },
         {
-          "Name": "23L",
-          "AirportConditions": null,
-          "Notams": null,
-          "ArbitraryText": null,
-          "Template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. RUNWAY IN USE 23L. SINGLE RUNWAY OPERATIONS. [TL]. [WX]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND REPORT AIRCRAFT TYPE AND CLEARED LEVEL ON FIRST CONTACT WITH MANCHESTER APPROACH RADAR."
-        },
-        {
-          "Name": "05R",
-          "AirportConditions": null,
-          "Notams": null,
-          "ArbitraryText": null,
-          "Template": "MANCHESTER INFORMATION [ATIS_CODE], TIME [TIME] AUTOMATIC. RUNWAY IN USE 05R. SINGLE RUNWAY OPERATIONS. [TL]. [WX]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND REPORT AIRCRAFT TYPE AND CLEARED LEVEL ON FIRST CONTACT WITH MANCHESTER APPROACH RADAR."
+          "string": "05R",
+          "spoken": "ZERO FIVE RIGHT"
         }
       ],
-      "AirportConditionDefinitions": [],
-      "NotamDefinitions": [],
-      "TransitionLevels": [
-        {
-          "Low": 1032,
-          "High": 1049,
-          "Altitude": 55
+      "airportConditionDefinitions": [],
+      "notamDefinitions": [],
+      "atisFormat": {
+        "observationTime": {
+          "template": {
+            "text": "{time}Z",
+            "voice": "{time} ZULU {special}"
+          }
         },
-        {
-          "Low": 1013,
-          "High": 1031,
-          "Altitude": 60
+        "surfaceWind": {
+          "speakLeadingZero": false,
+          "magneticVariation": {
+            "enabled": false,
+            "magneticDegrees": 0
+          },
+          "standard": {
+            "template": {
+              "text": "{wind_dir}{wind_spd}KT",
+              "voice": "SURFACE WIND {wind_dir} {wind_spd} {wind_unit}"
+            }
+          },
+          "standardGust": {
+            "template": {
+              "text": "{wind_dir}{wind_spd}G{wind_gust}KT",
+              "voice": "SURFACE WIND {wind_dir} {wind_spd} {wind_unit} GUSTS {wind_gust} {wind_unit}"
+            }
+          },
+          "variable": {
+            "template": {
+              "text": "VRB{wind_spd}KT",
+              "voice": "SURFACE WIND VARIABLE {wind_spd} {wind_unit}"
+            }
+          },
+          "variableGust": {
+            "template": {
+              "text": "VRB{wind_spd}G{wind_gust}KT",
+              "voice": "SURFACE WIND VARIABLE {wind_spd}{wind_unit} GUSTS {wind_gust}{wind_unit}"
+            }
+          },
+          "variableDirection": {
+            "template": {
+              "text": "{wind_vmin}V{wind_vmax}",
+              "voice": "SURFACE WIND VARIABLE BETWEEN {wind_vmin} AND {wind_vmax}"
+            }
+          },
+          "calm": {
+            "calmWindSpeed": 2,
+            "template": {
+              "text": "{wind}",
+              "voice": "WIND CALM"
+            }
+          }
         },
-        {
-          "Low": 995,
-          "High": 1012,
-          "Altitude": 65
+        "visibility": {
+          "north": "to the north",
+          "northEast": "to the north-east",
+          "east": "to the east",
+          "southEast": "to the south-east",
+          "south": "to the south",
+          "southWest": "to the south-west",
+          "west": "to the west",
+          "northWest": "to the north-west",
+          "unlimitedVisibilityVoice": "visibility 10 kilometers or more",
+          "unlimitedVisibilityText": "9999",
+          "includeVisibilitySuffix": false,
+          "metersCutoff": 5000,
+          "template": {
+            "text": "{visibility}",
+            "voice": "VISIBILITY {visibility}"
+          }
         },
-        {
-          "Low": 977,
-          "High": 994,
-          "Altitude": 70
+        "presentWeather": {
+          "lightIntensity": "light",
+          "moderateIntensity": "",
+          "heavyIntensity": "heavy",
+          "vicinity": "in vicinity",
+          "weatherTypes": {
+            "DZ": "drizzle",
+            "RA": "rain",
+            "SN": "snow",
+            "SG": "snow grains",
+            "IC": "ice crystals",
+            "PL": "ice pellets",
+            "GR": "hail",
+            "GS": "small hail",
+            "UP": "unknown precipitation",
+            "BR": "mist",
+            "FG": "fog",
+            "FU": "smoke",
+            "VA": "volcanic ash",
+            "DU": "widespread dust",
+            "SA": "sand",
+            "HZ": "haze",
+            "PY": "spray",
+            "PO": "well developed dust, sand whirls",
+            "SQ": "squalls",
+            "FC": "funnel cloud tornado waterspout",
+            "SS": "sandstorm",
+            "DS": "dust storm"
+          },
+          "weatherDescriptors": {
+            "PR": "partial",
+            "BC": "patches",
+            "MI": "shallow",
+            "DR": "low drifting",
+            "BL": "blowing",
+            "SH": "showers",
+            "TS": "thunderstorm",
+            "FZ": "freezing"
+          },
+          "template": {
+            "text": "{weather}",
+            "voice": "{weather}"
+          }
         },
-        {
-          "Low": 959,
-          "High": 976,
-          "Altitude": 75
+        "clouds": {
+          "identifyCeilingLayer": true,
+          "convertToMetric": false,
+          "types": {
+            "FEW": {
+              "$type": "Vatsim.Vatis.Profiles.AtisFormat.Nodes.CloudType, vATIS",
+              "text": "FEW{altitude}",
+              "voice": "few clouds at {altitude}"
+            },
+            "SCT": {
+              "$type": "Vatsim.Vatis.Profiles.AtisFormat.Nodes.CloudType, vATIS",
+              "text": "SCT{altitude}{convective}",
+              "voice": "{altitude} scattered {convective}"
+            },
+            "BKN": {
+              "$type": "Vatsim.Vatis.Profiles.AtisFormat.Nodes.CloudType, vATIS",
+              "text": "BKN{altitude}{convective}",
+              "voice": "{altitude} broken {convective}"
+            },
+            "OVC": {
+              "$type": "Vatsim.Vatis.Profiles.AtisFormat.Nodes.CloudType, vATIS",
+              "text": "OVC{altitude}{convective}",
+              "voice": "{altitude} overcast {convective}"
+            },
+            "VV": {
+              "$type": "Vatsim.Vatis.Profiles.AtisFormat.Nodes.CloudType, vATIS",
+              "text": "VV{altitude}",
+              "voice": "indefinite ceiling {altitude}"
+            },
+            "NSC": {
+              "$type": "Vatsim.Vatis.Profiles.AtisFormat.Nodes.CloudType, vATIS",
+              "text": "NSC",
+              "voice": "no significant clouds"
+            },
+            "NCD": {
+              "$type": "Vatsim.Vatis.Profiles.AtisFormat.Nodes.CloudType, vATIS",
+              "text": "NCD",
+              "voice": "no clouds detected"
+            },
+            "CLR": {
+              "$type": "Vatsim.Vatis.Profiles.AtisFormat.Nodes.CloudType, vATIS",
+              "text": "CLR",
+              "voice": "sky clear below one-two thousand"
+            },
+            "SKC": {
+              "$type": "Vatsim.Vatis.Profiles.AtisFormat.Nodes.CloudType, vATIS",
+              "text": "SKC",
+              "voice": "sky clear"
+            }
+          },
+          "convectiveTypes": {
+            "CB": "cumulonimbus",
+            "TCU": "towering cumulus"
+          },
+          "template": {
+            "text": "{clouds}",
+            "voice": "{clouds}"
+          }
         },
-        {
-          "Low": 940,
-          "High": 958,
-          "Altitude": 80
+        "temperature": {
+          "usePlusPrefix": false,
+          "pronounceLeadingZero": true,
+          "template": {
+            "text": "{temp}",
+            "voice": "TEMPERATURE {temp}"
+          }
+        },
+        "dewpoint": {
+          "usePlusPrefix": false,
+          "pronounceLeadingZero": true,
+          "template": {
+            "text": "{dewpoint}",
+            "voice": "DEWPOINT {dewpoint}"
+          }
+        },
+        "altimeter": {
+          "pronounceDecimal": false,
+          "template": {
+            "text": "Q{altimeter|hpa}",
+            "voice": "QNH {altimeter|hpa}"
+          }
+        },
+        "transitionLevel": {
+          "values": [
+            {
+              "low": 1032,
+              "high": 1049,
+              "altitude": 55
+            },
+            {
+              "low": 1013,
+              "high": 1031,
+              "altitude": 60
+            },
+            {
+              "low": 995,
+              "high": 1012,
+              "altitude": 65
+            },
+            {
+              "low": 977,
+              "high": 994,
+              "altitude": 70
+            },
+            {
+              "low": 959,
+              "high": 976,
+              "altitude": 75
+            },
+            {
+              "low": 940,
+              "high": 958,
+              "altitude": 80
+            }
+          ],
+          "template": {
+            "text": "TRANSITION LEVEL {trl}",
+            "voice": "TRANSITION LEVEL {trl}"
+          }
+        },
+        "closingStatement": {
+          "autoIncludeClosingStatement": true,
+          "template": {
+            "text": "ACKNOWLEDGE RECEIPT OF INFORMATION {letter} AND REPORT AIRCRAFT TYPE AND CLEARED LEVEL ON FIRST CONTACT WITH MANCHESTER APPROACH RADAR.",
+            "voice": "ACKNOWLEDGE RECEIPT OF INFORMATION {letter|word} AND REPORT AIRCRAFT TYPE AND CLEARED LEVEL ON FIRST CONTACT WITH MANCHESTER APPROACH RADAR."
+          }
         }
-      ],
-      "UseFaaFormat": false,
-      "UseNotamPrefix": false,
-      "UseTransitionLevelPrefix": true,
-      "UseMetricUnits": false,
-      "UseSurfaceWindPrefix": true,
-      "UseVisibilitySuffix": true,
-      "UseDecimalTerminology": true
+      }
     }
   ]
 }


### PR DESCRIPTION
Similar changes to the Gatwick profile:

- Improve runway pronunciation
- Support airport conditions and NOTAM fields
- UK phraseology for weather
- Changed altimeter to QNH
- Moved acknowledge part to closing statement